### PR TITLE
adds warning log when custom configuration is not found. 

### DIFF
--- a/packages/jest/src/custom-config.resolver.spec.ts
+++ b/packages/jest/src/custom-config.resolver.spec.ts
@@ -1,54 +1,63 @@
-
-import {getSystemPath, normalize} from "@angular-devkit/core";
-let jestConfig = {blah: true};
+import {getSystemPath, normalize} from '@angular-devkit/core';
 
 const existsSyncMock = jest.fn();
 jest.mock('fs', () => ({existsSync: existsSyncMock}));
 
-import {CustomConfigResolver} from "./custom-config.resolver";
+import {CustomConfigResolver} from './custom-config.resolver';
 
-describe("Resolve global custom config", () => {
+const jestConfig = {blah: true};
+const mockLogger = <any>{ warn: jest.fn() };
+const customConfigResolver = new CustomConfigResolver(mockLogger);
+
+describe('Resolve global custom config', () => {
   beforeEach(() => {
     jest.resetModules();
   });
 
-  it("Should return jest configuration from package.json if exists", () => {
+  it('Should return jest configuration from package.json if exists', () => {
     jest.mock('package.json', () => ({jest: jestConfig}), {virtual: true});
-    const customConfig = CustomConfigResolver.resolveGlobal(normalize('./'));
+    const customConfig = customConfigResolver.resolveGlobal(normalize('./'));
     expect(customConfig).toEqual(jestConfig);
   });
 
-  it("Should return jest configuration from workspace jest.config.js if exists and no configuration provided in package.json", () => {
+  it('Should return jest configuration from workspace jest.config.js if exists and no configuration provided in package.json', () => {
     jest.mock('package.json', () => ({}), {virtual: true});
     jest.mock('jest.config.js', () => jestConfig, {virtual: true});
     existsSyncMock.mockReturnValue(true);
-    const customConfig = CustomConfigResolver.resolveGlobal(normalize('./'));
+    const customConfig = customConfigResolver.resolveGlobal(normalize('./'));
     expect(customConfig).toEqual(jestConfig);
   });
 
-  it("Should return empty object if neither workspace jest.config.js nor package.json jest config exist", () => {
+  it('Should return empty object if neither workspace jest.config.js nor package.json jest config exist', () => {
     jest.mock('package.json', () => ({}), {virtual: true});
     existsSyncMock.mockReturnValue(false);
-    const customConfig = CustomConfigResolver.resolveGlobal(normalize('./'));
+    const customConfig = customConfigResolver.resolveGlobal(normalize('./'));
     expect(customConfig).toEqual({});
   });
 });
 
-describe("Resolve project custom config", () => {
+describe('Resolve project custom config', () => {
   beforeEach(() => {
     jest.resetModules();
+    jest.clearAllMocks();
   });
 
-  it("Should return jest configuration from project jest.config.js if exists", () => {
+  it('Should return jest configuration from project jest.config.js if exists', () => {
     jest.mock(getSystemPath(normalize('./myproject/project-jest.config.js')), () => jestConfig, {virtual: true});
     existsSyncMock.mockReturnValue(true);
-    const customConfig = CustomConfigResolver.resolveForProject(normalize('./myproject'), 'project-jest.config.js');
+    const customConfig = customConfigResolver.resolveForProject(normalize('./myproject'), 'project-jest.config.js');
     expect(customConfig).toEqual(jestConfig);
   });
 
-  it("Should return empty object if project jest.config.js doesn't exist", () => {
+  it('Should return empty object if project jest.config.js doesn\'t exist', () => {
     existsSyncMock.mockReturnValue(false);
-    const customConfig = CustomConfigResolver.resolveGlobal(normalize('./'));
+    const customConfig = customConfigResolver.resolveForProject(normalize('./myproject'), 'project-jest.config.js');
     expect(customConfig).toEqual({});
+  });
+
+  it('should log a warning when the custom configuration is not found', () => {
+    existsSyncMock.mockReturnValue(false);
+    customConfigResolver.resolveForProject(normalize('./myproject'), 'project-jest.config.js');
+    expect(mockLogger.warn.mock.calls.length).toBe(1);
   });
 });

--- a/packages/jest/src/custom-config.resolver.ts
+++ b/packages/jest/src/custom-config.resolver.ts
@@ -1,17 +1,26 @@
-import {getSystemPath, join, Path} from "@angular-devkit/core";
-import {existsSync} from "fs";
+import {getSystemPath, join, Path} from '@angular-devkit/core';
+import {existsSync} from 'fs';
+import {Logger} from '@angular-devkit/core/src/logger';
 
 export class CustomConfigResolver {
-  static resolveGlobal(workspaceRoot: Path): any {
+
+  constructor(private logger: Logger) {
+  }
+
+  resolveGlobal(workspaceRoot: Path): any {
     const packageJsonPath = getSystemPath(join(workspaceRoot, 'package.json'));
     const packageJson = require(packageJsonPath);
     const workspaceJestConfigPath = getSystemPath(join(workspaceRoot, 'jest.config.js'));
 
-    return packageJson.jest || existsSync(workspaceJestConfigPath) && require(workspaceJestConfigPath) || {}
+    return packageJson.jest || existsSync(workspaceJestConfigPath) && require(workspaceJestConfigPath) || {};
   }
 
-  static resolveForProject(projectRoot: Path, configPath: string){
+  resolveForProject(projectRoot: Path, configPath: string){
     const jestConfigPath = getSystemPath(join(projectRoot, configPath));
-    return existsSync(jestConfigPath) && require(jestConfigPath) || {};
+    if (!existsSync(jestConfigPath)) {
+      this.logger.warn(`warning: unable to locate custom jest configuration file at path "${jestConfigPath}"`);
+      return {};
+    }
+    return require(jestConfigPath);
   }
 }

--- a/packages/jest/src/default-config.resolver.spec.ts
+++ b/packages/jest/src/default-config.resolver.spec.ts
@@ -3,20 +3,22 @@ import {getSystemPath, normalize} from "@angular-devkit/core";
 
 import defaultConfig from './jest-config/default-config';
 
+const defaultConfigResolver = new DefaultConfigResolver();
+
 describe('Resolve project default configuration', () => {
   it('Should resolve tsconfig relatively to project root', () => {
-    const config = DefaultConfigResolver.resolveForProject(normalize('/some/cool/directory'));
+    const config = defaultConfigResolver.resolveForProject(normalize('/some/cool/directory'));
     expect(config.globals['ts-jest'].tsConfigFile).toEqual(getSystemPath(normalize(`/some/cool/directory/${tsConfigName}`)));
   });
 
   it('Should resolve testMatch pattern relatively to project root', () => {
-    const config = DefaultConfigResolver.resolveForProject(normalize('/some/cool/directory'));
+    const config = defaultConfigResolver.resolveForProject(normalize('/some/cool/directory'));
     expect(config.testMatch).toEqual([getSystemPath(normalize(`/some/cool/directory/${testPattern}`))]);
   });
 });
 
 describe('Resolve global default configuration', () => {
   it('Should resolve default config from predefined config module', () => {
-    expect(DefaultConfigResolver.resolveGlobal()).toEqual(defaultConfig);
+    expect(defaultConfigResolver.resolveGlobal()).toEqual(defaultConfig);
   });
 });

--- a/packages/jest/src/default-config.resolver.ts
+++ b/packages/jest/src/default-config.resolver.ts
@@ -5,11 +5,12 @@ export const testPattern = `/**/+(*.)+(spec|test).+(ts|js)?(x)`;
 export const tsConfigName = 'tsconfig.spec.json';
 
 export class DefaultConfigResolver {
-  static resolveGlobal(): any {
+
+  resolveGlobal(): any {
     return defaultConfig;
   }
 
-  static resolveForProject(projectRoot: Path): any {
+  resolveForProject(projectRoot: Path): any {
     return {
       globals: {
         'ts-jest': {

--- a/packages/jest/src/jest-configuration-builder.spec.ts
+++ b/packages/jest/src/jest-configuration-builder.spec.ts
@@ -1,60 +1,60 @@
 import {normalize} from "@angular-devkit/core";
-
-jest.mock('./default-config.resolver', () => ({
-  DefaultConfigResolver: {
-    resolveGlobal: jest.fn(),
-    resolveForProject: jest.fn()
-  }
-}));
-jest.mock('./custom-config.resolver', () => ({
-  CustomConfigResolver: {
-    resolveGlobal: jest.fn(),
-    resolveForProject: jest.fn()
-  }
-}));
-
 import {JestConfigurationBuilder} from "./jest-configuration-builder";
-import {DefaultConfigResolver} from "./default-config.resolver";
-import {CustomConfigResolver} from "./custom-config.resolver";
 
 describe("Build Jest configuration object", () => {
+
+  let defaultConfigResolver: any;
+  let customConfigResolver: any;
+  let jestConfigurationBuilder: JestConfigurationBuilder;
+
   beforeEach(() => {
-    jest.clearAllMocks();
+    defaultConfigResolver = {
+      resolveGlobal: jest.fn(),
+      resolveForProject: jest.fn()
+    };
+    customConfigResolver = {
+      resolveGlobal: jest.fn(),
+      resolveForProject: jest.fn()
+    };
+    jestConfigurationBuilder = new JestConfigurationBuilder(
+      defaultConfigResolver,
+      customConfigResolver
+    );
   });
 
   it("Should resolve projects with source root instead of root if the former exists and the latter is empty", () => {
     const sourceRoot = normalize('/my/source/root');
-    JestConfigurationBuilder.buildConfiguration(normalize(''), sourceRoot, normalize('./'), 'jest.config.js');
-    expect(DefaultConfigResolver.resolveForProject.mock.calls[0][0]).toEqual(sourceRoot);
-    expect(CustomConfigResolver.resolveForProject.mock.calls[0][0]).toEqual(sourceRoot);
+    jestConfigurationBuilder.buildConfiguration(normalize(''), sourceRoot, normalize('./'), 'jest.config.js');
+    expect(defaultConfigResolver.resolveForProject.mock.calls[0][0]).toEqual(sourceRoot);
+    expect(customConfigResolver.resolveForProject.mock.calls[0][0]).toEqual(sourceRoot);
   });
 
   it("Should use root even if it's empty when source root is not provided", () => {
-    JestConfigurationBuilder.buildConfiguration(normalize(''), undefined, normalize('./'), 'jest.config.js');
-    expect(DefaultConfigResolver.resolveForProject.mock.calls[0][0]).toEqual('');
-    expect(CustomConfigResolver.resolveForProject.mock.calls[0][0]).toEqual('');
+    jestConfigurationBuilder.buildConfiguration(normalize(''), undefined, normalize('./'), 'jest.config.js');
+    expect(defaultConfigResolver.resolveForProject.mock.calls[0][0]).toEqual('');
+    expect(customConfigResolver.resolveForProject.mock.calls[0][0]).toEqual('');
   });
 
   it("Should prefer root over source root if the former is not empty", () => {
     const root = normalize('/my/root');
-    JestConfigurationBuilder.buildConfiguration(root, normalize('/my/source/root'), normalize('./'), 'jest.config.js');
-    expect(DefaultConfigResolver.resolveForProject.mock.calls[0][0]).toEqual(root);
-    expect(CustomConfigResolver.resolveForProject.mock.calls[0][0]).toEqual(root);
+    jestConfigurationBuilder.buildConfiguration(root, normalize('/my/source/root'), normalize('./'), 'jest.config.js');
+    expect(defaultConfigResolver.resolveForProject.mock.calls[0][0]).toEqual(root);
+    expect(customConfigResolver.resolveForProject.mock.calls[0][0]).toEqual(root);
   });
 
   it("Should use jest.config.js path if configPath is not provided", () => {
-    JestConfigurationBuilder.buildConfiguration(normalize(''), undefined, normalize('./'));
-    expect(CustomConfigResolver.resolveForProject.mock.calls[0][1]).toEqual('jest.config.js');
+    jestConfigurationBuilder.buildConfiguration(normalize(''), undefined, normalize('./'));
+    expect(customConfigResolver.resolveForProject.mock.calls[0][1]).toEqual('jest.config.js');
   });
 
   it("Should use provided configPath when resolving custom project configuration", () => {
     const jestConfigPath = '../my-jest.config.js';
-    JestConfigurationBuilder.buildConfiguration(normalize(''), undefined, normalize('./'), jestConfigPath);
-    expect(CustomConfigResolver.resolveForProject.mock.calls[0][1]).toEqual(jestConfigPath);
+    jestConfigurationBuilder.buildConfiguration(normalize(''), undefined, normalize('./'), jestConfigPath);
+    expect(customConfigResolver.resolveForProject.mock.calls[0][1]).toEqual(jestConfigPath);
   });
 
   it("Should merge configs in the following order: defaultGlobalConfig <- defaultProjectConfig <- customGlobalConfig <- customProjectConfig", () => {
-    DefaultConfigResolver.resolveGlobal.mockReturnValue({
+    defaultConfigResolver.resolveGlobal.mockReturnValue({
       global: {
         default: 0,
         notSoDefault: true,
@@ -64,7 +64,7 @@ describe("Build Jest configuration object", () => {
         default: 3,
       }
     });
-    DefaultConfigResolver.resolveForProject.mockReturnValue({
+    defaultConfigResolver.resolveForProject.mockReturnValue({
       global: {
         notSoDefault: false
       },
@@ -73,7 +73,7 @@ describe("Build Jest configuration object", () => {
         notSoDefault: "blah"
       }
     });
-    CustomConfigResolver.resolveGlobal.mockReturnValue({
+    customConfigResolver.resolveGlobal.mockReturnValue({
       global: {
         default: 2
       },
@@ -82,12 +82,12 @@ describe("Build Jest configuration object", () => {
         notSoDefault: "blah blah"
       }
     });
-    CustomConfigResolver.resolveForProject.mockReturnValue({
+    customConfigResolver.resolveForProject.mockReturnValue({
       project: {
         default: 5
       }
     });
-    const config = JestConfigurationBuilder.buildConfiguration(normalize(''), undefined, normalize('./'));
+    const config = jestConfigurationBuilder.buildConfiguration(normalize(''), undefined, normalize('./'));
 
     expect(config).toEqual({
       global: {

--- a/packages/jest/src/jest-configuration-builder.ts
+++ b/packages/jest/src/jest-configuration-builder.ts
@@ -5,14 +5,19 @@ import {CustomConfigResolver} from "./custom-config.resolver";
 import {DefaultConfigResolver} from "./default-config.resolver";
 
 export class JestConfigurationBuilder {
-  static buildConfiguration(root: Path, sourceRoot: Path | undefined, workspaceRoot: Path, configPath: string = 'jest.config.js'): any {
+
+  constructor(private defaultConfigResolver: DefaultConfigResolver,
+              private customConfigResolver: CustomConfigResolver) {
+  }
+
+  buildConfiguration(root: Path, sourceRoot: Path | undefined, workspaceRoot: Path, configPath: string = 'jest.config.js'): any {
     const configRoot = root === '' ? sourceRoot || normalize('') : root ;
     const projectRoot: Path = resolve(workspaceRoot, configRoot);
 
-    const globalDefaultConfig = DefaultConfigResolver.resolveGlobal();
-    const projectDefaultConfig = DefaultConfigResolver.resolveForProject(projectRoot);
-    const globalCustomConfig = CustomConfigResolver.resolveGlobal(workspaceRoot);
-    const globalProjectConfig = CustomConfigResolver.resolveForProject(projectRoot, configPath);
+    const globalDefaultConfig = this.defaultConfigResolver.resolveGlobal();
+    const projectDefaultConfig = this.defaultConfigResolver.resolveForProject(projectRoot);
+    const globalCustomConfig = this.customConfigResolver.resolveGlobal(workspaceRoot);
+    const globalProjectConfig = this.customConfigResolver.resolveForProject(projectRoot, configPath);
 
     return merge(globalDefaultConfig, projectDefaultConfig, globalCustomConfig, globalProjectConfig);
   }

--- a/packages/jest/src/jest.builder.ts
+++ b/packages/jest/src/jest.builder.ts
@@ -5,21 +5,31 @@ import {JestBuilderSchema} from './schema';
 
 import {OptionsConverter} from "./options-converter";
 import {JestConfigurationBuilder} from "./jest-configuration-builder";
+import { DefaultConfigResolver } from './default-config.resolver';
+import { CustomConfigResolver } from './custom-config.resolver';
 
 const jest = require('jest');
 
 export default class JestBuilder implements Builder<JestBuilderSchema> {
+
+  private jestConfigurationBuilder: JestConfigurationBuilder;
+  private optionsConverter: OptionsConverter;
+
   constructor(private context: BuilderContext) {
+    this.jestConfigurationBuilder = new JestConfigurationBuilder(
+      new DefaultConfigResolver(),
+      new CustomConfigResolver(context.logger)
+    );
+    this.optionsConverter = new OptionsConverter();
   }
 
   run(builderConfig: BuilderConfiguration<Partial<JestBuilderSchema>>): Observable<BuildEvent> {
     const {options, root, sourceRoot} = builderConfig;
     const workspaceRoot = this.context.workspace.root;
 
-    const configuration = JestConfigurationBuilder.buildConfiguration(root, sourceRoot, workspaceRoot, options.configPath);
+    const configuration = this.jestConfigurationBuilder.buildConfiguration(root, sourceRoot, workspaceRoot, options.configPath);
     delete options.configPath;
-    const argv = OptionsConverter.convertToCliArgs(options);
-
+    const argv = this.optionsConverter.convertToCliArgs(options);
 
     argv.push('--config', JSON.stringify(configuration));
     return from(jest.run(argv)).pipe(map(() => ({success: true})));

--- a/packages/jest/src/options-converter.spec.ts
+++ b/packages/jest/src/options-converter.spec.ts
@@ -1,18 +1,21 @@
 import {OptionsConverter} from "./options-converter";
 
 describe("Convert options to Jest CLI arguments", () => {
+
+  const optionsConverter = new OptionsConverter();
+
   it("Should convert options with value TRUE to no value argument", () => {
-    const argv = OptionsConverter.convertToCliArgs({trueOption: true});
+    const argv = optionsConverter.convertToCliArgs({trueOption: true});
     expect(argv).toContain("--trueOption");
   });
 
   it("Should convert options with string value argument-name=argument-value form", () => {
-    const argv = OptionsConverter.convertToCliArgs({stringOption: 'somestring'});
+    const argv = optionsConverter.convertToCliArgs({stringOption: 'somestring'});
     expect(argv).toContain("--stringOption=somestring");
   });
 
   it("Should handle different arguments types provided in single object", () => {
-    const argv = OptionsConverter.convertToCliArgs({stringOption: 'some string', booleanOption: true});
+    const argv = optionsConverter.convertToCliArgs({stringOption: 'some string', booleanOption: true});
     expect(argv).toEqual(['--stringOption=some string', "--booleanOption"]);
   });
 });

--- a/packages/jest/src/options-converter.ts
+++ b/packages/jest/src/options-converter.ts
@@ -1,7 +1,7 @@
 import {JestBuilderSchema} from "./schema";
 
 export class OptionsConverter {
-  static convertToCliArgs(options: Partial<JestBuilderSchema>): string[] {
+  convertToCliArgs(options: Partial<JestBuilderSchema>): string[] {
     const argv = [];
     for (const option of Object.keys(options)) {
       let optionValue = options[option];


### PR DESCRIPTION
Addresses issue: https://github.com/meltedspark/angular-builders/issues/84

In this effort I had to restructure the code to use instance methods instead of static ones to get the logger down to the custom config resolver instance.

