### PR TITLE
feat(custom-webpack): Export function in webpack configuration

### DIFF
--- a/packages/custom-webpack/src/browser/index.ts
+++ b/packages/custom-webpack/src/browser/index.ts
@@ -24,7 +24,7 @@ export class CustomWebpackBrowserBuilder extends BrowserBuilder {
                      host: virtualFs.Host<fs.Stats>,
                      options: NormalizedCustomWebpackBrowserBuildSchema): Configuration {
 	  const browserWebpackConfig = super.buildWebpackConfig(root, projectRoot, host, options);
-	  return CustomWebpackBuilder.buildWebpackConfig(root, options.customWebpackConfig, browserWebpackConfig);
+	  return CustomWebpackBuilder.buildWebpackConfig(root, options.customWebpackConfig, browserWebpackConfig, options);
   }
 }
 

--- a/packages/custom-webpack/src/custom-webpack-builder.spec.ts
+++ b/packages/custom-webpack/src/custom-webpack-builder.spec.ts
@@ -30,14 +30,14 @@ describe('CustomWebpackBuilder test', () => {
 	it('Should load webpack.config.js if no path specified', () => {
 		fileName = defaultWebpackConfigPath;
 		createConfigFile(fileName);
-		CustomWebpackBuilder.buildWebpackConfig(__dirname as Path, {}, baseWebpackConfig);
+		CustomWebpackBuilder.buildWebpackConfig(__dirname as Path, {}, baseWebpackConfig, undefined);
 		expect(WebpackConfigMerger.merge).toHaveBeenCalledWith(baseWebpackConfig, customWebpackConfig, undefined, undefined);
 	});
 
 	it('Should load the file specified in configuration', () => {
 		fileName = 'extra-webpack.config.js';
 		createConfigFile(fileName);
-		CustomWebpackBuilder.buildWebpackConfig(__dirname as Path, {path: 'extra-webpack.config.js'}, baseWebpackConfig);
+		CustomWebpackBuilder.buildWebpackConfig(__dirname as Path, {path: 'extra-webpack.config.js'}, baseWebpackConfig, undefined);
 		expect(WebpackConfigMerger.merge).toHaveBeenCalledWith(baseWebpackConfig, customWebpackConfig, undefined, undefined);
 	});
 
@@ -45,14 +45,14 @@ describe('CustomWebpackBuilder test', () => {
 		fileName = defaultWebpackConfigPath;
 		createConfigFile(fileName);
 		const mergeStrategies: MergeStrategies = {'blah': 'prepend'};
-		CustomWebpackBuilder.buildWebpackConfig(__dirname as Path, {mergeStrategies}, baseWebpackConfig);
+		CustomWebpackBuilder.buildWebpackConfig(__dirname as Path, {mergeStrategies}, baseWebpackConfig, undefined);
 		expect(WebpackConfigMerger.merge).toHaveBeenCalledWith(baseWebpackConfig, customWebpackConfig, mergeStrategies, undefined);
 	});
 
 	it('Should pass on replaceDuplicatePlugins flag', () => {
 		fileName = defaultWebpackConfigPath;
 		createConfigFile(fileName);
-		CustomWebpackBuilder.buildWebpackConfig(__dirname as Path, {replaceDuplicatePlugins: true}, baseWebpackConfig);
+		CustomWebpackBuilder.buildWebpackConfig(__dirname as Path, {replaceDuplicatePlugins: true}, baseWebpackConfig, undefined);
 		expect(WebpackConfigMerger.merge).toHaveBeenCalledWith(baseWebpackConfig, customWebpackConfig, undefined, true);
 	});
 });

--- a/packages/custom-webpack/src/custom-webpack-builder.ts
+++ b/packages/custom-webpack/src/custom-webpack-builder.ts
@@ -1,14 +1,20 @@
-import {CustomWebpackBuilderConfig} from "./custom-webpack-builder-config";
-import {Configuration} from "webpack";
-import {getSystemPath, Path} from '@angular-devkit/core';
-import {WebpackConfigMerger} from "./webpack-config-merger";
+import { CustomWebpackBuilderConfig } from "./custom-webpack-builder-config";
+import { Configuration } from "webpack";
+import { getSystemPath, Path } from '@angular-devkit/core';
+import { WebpackConfigMerger } from "./webpack-config-merger";
 
 export const defaultWebpackConfigPath = 'webpack.config.js';
 
 export class CustomWebpackBuilder {
-	static buildWebpackConfig(root: Path, config: CustomWebpackBuilderConfig, baseWebpackConfig: Configuration): Configuration{
-		const webpackConfigPath = config.path || defaultWebpackConfigPath;
-		const customWebpackConfig = require(`${getSystemPath(root)}/${webpackConfigPath}`);
-		return WebpackConfigMerger.merge(baseWebpackConfig, customWebpackConfig, config.mergeStrategies, config.replaceDuplicatePlugins);
-	}
+    static buildWebpackConfig(root: Path, config: CustomWebpackBuilderConfig, baseWebpackConfig: Configuration, buildOptions: any): Configuration {
+        const webpackConfigPath = config.path || defaultWebpackConfigPath;
+        const customWebpackConfig = require(`${getSystemPath(root)}/${webpackConfigPath}`);
+        let customWebpackConfigObj = {};
+        if (typeof customWebpackConfig == "object")
+            customWebpackConfigObj = customWebpackConfig;
+        else if (typeof customWebpackConfig == "function")
+            customWebpackConfigObj = customWebpackConfig(buildOptions);
+
+        return WebpackConfigMerger.merge(baseWebpackConfig, customWebpackConfigObj, config.mergeStrategies, config.replaceDuplicatePlugins);
+    }
 }

--- a/packages/custom-webpack/src/karma/index.ts
+++ b/packages/custom-webpack/src/karma/index.ts
@@ -23,7 +23,7 @@ export class CustomWebpackKarmaBuilder extends KarmaBuilder {
                      host: virtualFs.Host<fs.Stats>,
                      options: NormalizedCustomWebpackBrowserBuildSchema): Configuration {
     const karmaConfig = KarmaBuilder.prototype['_buildWebpackConfig'].call(this, root, projectRoot, sourceRoot, host, options);
-	  return CustomWebpackBuilder.buildWebpackConfig(root, options.customWebpackConfig, karmaConfig);
+	  return CustomWebpackBuilder.buildWebpackConfig(root, options.customWebpackConfig, karmaConfig, options);
   }
 }
 

--- a/packages/custom-webpack/src/karma/karma-builder.spec.ts
+++ b/packages/custom-webpack/src/karma/karma-builder.spec.ts
@@ -34,7 +34,7 @@ describe('Custom webpack karma builder test', () => {
     buildWebpackConfigMock.mockReturnValue(mergedConfig);
     const root = `${__dirname}/../../../../`;
     const config = builder['_buildWebpackConfig'](root, root, "./", {}, options);
-    expect(buildWebpackConfigMock).toHaveBeenCalledWith(root, options.customWebpackConfig, angularConfigs);
+    expect(buildWebpackConfigMock).toHaveBeenCalledWith(root, options.customWebpackConfig, angularConfigs, options);
     expect(config).toEqual(mergedConfig);
   })
 });

--- a/packages/custom-webpack/src/server/index.ts
+++ b/packages/custom-webpack/src/server/index.ts
@@ -22,7 +22,7 @@ export class CustomWebpackServerBuilder extends ServerBuilder {
 					   options: BuildWebpackServerSchema) {
 		const serverWebpackConfig = super.buildWebpackConfig(root, projectRoot, host, options);
 		const opt = options as CustomWebpackServerBuildSchema;
-		return CustomWebpackBuilder.buildWebpackConfig(root, opt.customWebpackConfig, serverWebpackConfig) as any;
+		return CustomWebpackBuilder.buildWebpackConfig(root, opt.customWebpackConfig, serverWebpackConfig, options) as any;
 	}
 }
 


### PR DESCRIPTION
Add the possibility to export a function in webpack custom configuration.
The function takes the angular build option as parameter.

The need for this feature was mentioned in the issue : #135 

exemple :
````javascript
module.exports = (buildOptions) => ({
    devtool: buildOptions.sourceMap ? 'source-map' : false
});
````