### PR TITLE
Removed underscore prefix for Angular 7 buildWebpackConfig

### DIFF
--- a/packages/custom-webpack/src/karma/index.ts
+++ b/packages/custom-webpack/src/karma/index.ts
@@ -22,7 +22,7 @@ export class CustomWebpackKarmaBuilder extends KarmaBuilder {
                      sourceRoot: Path,
                      host: virtualFs.Host<fs.Stats>,
                      options: NormalizedCustomWebpackBrowserBuildSchema): Configuration {
-    const karmaConfig = KarmaBuilder.prototype['_buildWebpackConfig'].call(this, root, projectRoot, sourceRoot, host, options);
+    const karmaConfig = KarmaBuilder.prototype['buildWebpackConfig'].call(this, root, projectRoot, sourceRoot, host, options);
 	  return CustomWebpackBuilder.buildWebpackConfig(root, options.customWebpackConfig, karmaConfig);
   }
 }


### PR DESCRIPTION
In the @angular/devkit/build-angular v7 the buildWebpackConfig method is no longer private and renamed to 'buildWebpackConfig' without the underscore prefix.