### PR TITLE
fix(jest): add correct schema typing for collectCoverageFrom

### DIFF
--- a/packages/jest/src/schema.json
+++ b/packages/jest/src/schema.json
@@ -59,11 +59,7 @@
       "type": "boolean"
     },
     "collectCoverageFrom": {
-      "description": "A glob pattern relative to <rootDir> matching the files that coverage info needs to be collected from.",
-      "type": "array"
-    },
-    "collectCoverageOnlyFrom": {
-      "description": "Explicit list of paths coverage will be restricted to.",
+      "description": "An array of glob patterns indicating a set of files for which coverage information should be collected. If a file matches the specified glob pattern, coverage information will be collected for it even if no tests exist for this file and it's never required in the test suite",
       "type": "array"
     },
     "color": {

--- a/packages/jest/src/schema.json
+++ b/packages/jest/src/schema.json
@@ -60,7 +60,7 @@
     },
     "collectCoverageFrom": {
       "description": "A glob pattern relative to <rootDir> matching the files that coverage info needs to be collected from.",
-      "type": "string"
+      "type": "array"
     },
     "collectCoverageOnlyFrom": {
       "description": "Explicit list of paths coverage will be restricted to.",


### PR DESCRIPTION
According to the docs, https://jestjs.io/docs/en/configuration.html#collectcoveragefrom-array, this item is an array and not a string