### PR TITLE
chore(package): include subdirectories from typings for package

### DIFF
--- a/packages/custom-webpack/.yarnignore
+++ b/packages/custom-webpack/.yarnignore
@@ -7,7 +7,7 @@
 
 **/*.ts
 **/*.js.map
-!typings/*
+!typings/**/*
 examples
 typings/schemes.d.ts
 schemes.js

--- a/packages/dev-server/.yarnignore
+++ b/packages/dev-server/.yarnignore
@@ -8,7 +8,7 @@
 
 **/*.ts
 **/*.js.map
-!typings/*
+!typings/**/*
 typings/schemes.d.ts
 schemes.js
 

--- a/packages/jest/.yarnignore
+++ b/packages/jest/.yarnignore
@@ -7,7 +7,7 @@
 
 **/*.ts
 **/*.js.map
-!typings/*
+!typings/**/*
 
 examples
 

--- a/packages/timestamp/.yarnignore
+++ b/packages/timestamp/.yarnignore
@@ -7,7 +7,7 @@
 
 **/*.ts
 **/*.js.map
-!typings/*
+!typings/**/*
 !timestamp.builder.js
 
 example


### PR DESCRIPTION
This fixes #207

This is a replacement for #208. We have decided not to use `files` since it doesn't work properly with `yarn` at this time.