### PR TITLE
Support Ionic build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+This is a fork from [meltedspark/angular-builders](https://github.com/meltedspark/angular-builders) that supports Ionic.
+You will be able to customize the Webpack build configuration with Ionic
+
 # @angular-builders [![Build Status](https://travis-ci.org/meltedspark/angular-builders.svg?branch=master)](https://travis-ci.org/meltedspark/angular-builders) [![Greenkeeper badge](https://badges.greenkeeper.io/meltedspark/angular-builders.svg)](https://greenkeeper.io/) ![Packagist](https://img.shields.io/packagist/l/doctrine/orm.svg)  
 
 The purpose of this repository is to consolidate all the community builders for Angular build facade.

--- a/packages/custom-webpack/builders.json
+++ b/packages/custom-webpack/builders.json
@@ -16,6 +16,11 @@
       "schema": "./dist/dev-server/schema.json",
       "description": "Dev server extended with custom webpack config"
     },
+    "cordova-build": {
+      "class": "../../@ionic/angular-toolkit/builders/cordova-build",
+      "schema": "../../@ionic/angular-toolkit/builders/cordova-build/schema.json",
+      "description": "Perform a browser build with Cordova assets."
+    },
     "karma": {
       "implementation": "./dist/karma",
       "schema": "./dist/karma/schema.json",


### PR DESCRIPTION
This adds the support for ionic build to use the custom angular builder.

Ionic uses their own class and schema. So I referenced them from their project, as anyone wants to use this builder, then it should have the @ionic dependency.
